### PR TITLE
Add output for error handling

### DIFF
--- a/cmd/git-br/main.go
+++ b/cmd/git-br/main.go
@@ -14,13 +14,13 @@ func main() {
 	}
 	uiRunner, err := gitbr.Open(path)
 	if err != nil {
-		fmt.Sprintf("Error: %s", err.Error())
+		fmt.Printf("Error: %s\n", err.Error())
 		os.Exit(1)
 	}
 
 	err = uiRunner.Run()
 	if err != nil {
-		fmt.Sprintf("Error: %s", err.Error())
+		fmt.Printf("Error: %s\n", err.Error())
 		os.Exit(1)
 	}
 

--- a/gitbr.go
+++ b/gitbr.go
@@ -2,7 +2,6 @@ package gitbr
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -21,15 +20,6 @@ type UIRunner interface {
 
 // Open returns an UIRunner from a git repository filesystem path.
 func Open(path string) (UIRunner, error) {
-	_, err := os.Stat(path + "/.git")
-	if err != nil && !os.IsNotExist(err) {
-		return nil, err
-	}
-
-	if os.IsNotExist(err) {
-		return nil, fmt.Errorf("no .git directory detected (needs to be in repository toplevel).")
-	}
-
 	repo, err := git.PlainOpen(path)
 	if err != nil {
 		return nil, err

--- a/gitbr.go
+++ b/gitbr.go
@@ -2,6 +2,7 @@ package gitbr
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -20,6 +21,15 @@ type UIRunner interface {
 
 // Open returns an UIRunner from a git repository filesystem path.
 func Open(path string) (UIRunner, error) {
+	_, err := os.Stat(path + "/.git")
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("no .git directory detected (needs to be in repository toplevel).")
+	}
+
 	repo, err := git.PlainOpen(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This adds output for errors, previously it was `fmt.Sprintf` which will only
format and doesn't output the string.

The commit also provides more information about when the command isn't run in
the git toplevel. This could be solved by using `git rev-parse
--show-toplevel` but as far as I can tell, this isn't supported in go-git
right now.

Super useful utility, thank you for creating this!